### PR TITLE
Fix regexp for new Firefox

### DIFF
--- a/lib/browser_detect.dart
+++ b/lib/browser_detect.dart
@@ -35,7 +35,7 @@ Browser _ie = new Browser("IE",
 
 Browser _firefox = new Browser("Firefox",
     () => window.navigator.userAgent.contains("Firefox"),
-    () => new RegExp(r"rv:/?(.*)\)").firstMatch(window.navigator.userAgent).group(1));
+    () => new RegExp(r"rv:(.*)\)").firstMatch(window.navigator.userAgent).group(1));
 
 bool _matchVendor(String name) {
   var vendor = window.navigator.vendor;


### PR DESCRIPTION
@danschultz PTAL

It seems like new FF's User Agent contains something like rv:26.0
instead of rv:/26.0. Fixed it to work with both versions.
