### PR TITLE
Make browser_detect strong mode compliant

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -30,7 +30,7 @@ class Browser {
 }
 
 class _UnknownBrowser extends Browser {
-  _UnknownBrowser() : super("Unknown Browser", [() => true], [() => ""]);
+  _UnknownBrowser() : super("Unknown Browser", [() => true], [() => null]);
 }
 
 typedef bool _VendorMatcher();


### PR DESCRIPTION
Hey, in order to use the [DDC](https://webdev.dartlang.org/tools/dartdevc) all libraries need to be strong mode compliant.

I added the `.analysis_options` file for that, and made a minor necessary change to make it compliant.