### PR TITLE
be compatible with ddc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dart files and folders
 pubspec.lock
 packages
+.packages
+.idea
+.pub
 .buildlog
 build
 out

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,19 @@
+# see https://www.dartlang.org/guides/language/analysis-options#the-analysis-options-file
+analyzer:
+  strong-mode: true
+    implicit-casts: false
+    implicit-dynamic: false
+#   exclude:
+#     - path/to/excluded/files/**
+
+# Lint rules and documentation, see http://dart-lang.github.io/linter/lints
+linter:
+  rules:
+    - cancel_subscriptions
+    - close_sinks
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - test_types_in_equals
+    - unrelated_type_equality_checks
+    - valid_regexps

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -30,7 +30,7 @@ class Browser {
 }
 
 class _UnknownBrowser extends Browser {
-  _UnknownBrowser() : super("Unknown Browser", [() => true], [() => ""]);
+  _UnknownBrowser() : super("Unknown Browser", [() => true], [() => null]);
 }
 
 typedef bool _VendorMatcher();

--- a/lib/src/browser_version.dart
+++ b/lib/src/browser_version.dart
@@ -8,6 +8,9 @@ class BrowserVersion implements Comparable<BrowserVersion> {
   Iterable<int> _elements;
   Iterable<int> get elements {
     if (_elements == null) {
+      if(value == null) {
+        _elements = [];
+      }
       _elements = value.split(".").map((value) => int.parse(value, onError: (_) => 0));
     }
     return _elements;
@@ -53,7 +56,7 @@ class BrowserVersion implements Comparable<BrowserVersion> {
     return other is BrowserVersion ? compareTo(other) == 0 : false;
   }
 
-  int get hashCode => value.hashCode;
+  int get hashCode => value != null ? value.hashCode : 0;
 
   String toString() => value;
 }


### PR DESCRIPTION
  Hello,

I know this project hasn't been moving recently, but we're still using it :)

And when trying to develop with dart dev compiler (ddc), we got this message:
```
Error compiling dartdevc module:browser_detect|lib/lib__browser_detect.js

[error] The element type '() â†’ String' can't be assigned to the list type '_VersionMatcher() â†’ Match'. (package:browser_detect/src/browser.dart, line 33, col 63)

Please fix all errors before compiling (warnings are okay).
```

Please review this patch that corrects the issue for us.

Regards